### PR TITLE
Update Metadata.offset to use 'bytesize'

### DIFF
--- a/lib/dropbox_api/endpoints/files/upload_session_start.rb
+++ b/lib/dropbox_api/endpoints/files/upload_session_start.rb
@@ -31,7 +31,7 @@ module DropboxApi::Endpoints::Files
 
       DropboxApi::Metadata::UploadSessionCursor.new({
         "session_id" => session.session_id,
-        "offset" => content.size
+        "offset" => content.bytesize
       })
     end
   end


### PR DESCRIPTION
Fixes issue #19.
size will return the character length, whereas bytesize will return the length of the content in bytes.  transfers of binary files were failing with with an incorrect offset prior to this change.